### PR TITLE
feat: add Fish shell configuration with Zsh compatibility

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -1,0 +1,89 @@
+# Fish configuration - converted from Zsh setup
+
+# Environment variables from .zshrc
+set -gx PATH $PATH /Users/biwsantang/.cache/lm-studio/bin
+set -gx PATH /Users/biwsantang/.bun/bin $PATH
+set -gx PATH $PATH /Users/biwsantang/.local/bin
+
+# Editor configuration
+set -gx EDITOR "/opt/homebrew/bin/nvim"
+set -gx VISUAL "/opt/homebrew/bin/nvim"
+
+# Bat theme
+set -gx BAT_THEME "ansi"
+
+# Starship prompt configuration
+set -gx STARSHIP_CONFIG ~/.config/starship/lookgood.toml
+starship init fish | source
+
+# CodeEdit shell integration
+if test "$TERM_PROGRAM" = "CodeEditApp_Terminal"
+    source "/Applications/CodeEdit.app/Contents/Resources/codeedit_shell_integration.fish" 2>/dev/null
+end
+
+# Forgit plugin (if available)
+if test -f $HOMEBREW_PREFIX/share/forgit/forgit.plugin.fish
+    source $HOMEBREW_PREFIX/share/forgit/forgit.plugin.fish
+end
+
+if status is-interactive
+    # Aliases (converted from Zsh)
+    alias c="clear"
+    alias ls="eza"
+    alias ll="ls -lahF"
+    alias cat="bat"
+    alias mkdir="mkdir -p"
+    alias cp="cp -r"
+    alias cb="cd .."
+    alias ch="cd ~"
+    alias cc="claude"
+    alias ccb="claude --dangerously-skip-permissions"
+    alias ccc="claude --dangerously-skip-permissions '/commit'"
+    alias ccpr="claude --dangerously-skip-permissions '/pr'"
+
+    # Functions (converted from Zsh)
+
+    # History search function
+    function hs
+        set -l selected (history --max=100 | fzf --tac --no-sort)
+        if test -n "$selected"
+            commandline -r $selected
+            commandline -f repaint
+        end
+    end
+
+    # Tmux session function
+    function t
+        set -l session_name
+        if test (count $argv) -eq 0
+            set session_name "0"
+        else
+            set session_name "X"
+        end
+        tmux new-session -A -s $session_name
+    end
+
+    # Edit command line function (Zsh equivalent)
+    function edit_command_line
+        set -l tmpfile (mktemp)
+        commandline > $tmpfile
+        $EDITOR $tmpfile
+        if test -s $tmpfile
+            commandline -r (cat $tmpfile)
+        end
+        rm -f $tmpfile
+    end
+
+    # Key bindings
+    bind \ce edit_command_line
+
+    # Fish-specific enhancements
+    # Disable greeting
+    set fish_greeting ""
+
+    # Enable autosuggestions color
+    set -g fish_color_autosuggestion 555
+
+    # Enable completion with underline for valid paths
+    set -g fish_color_valid_path --underline
+end


### PR DESCRIPTION
## Summary
- Add comprehensive Fish shell configuration with full Zsh compatibility
- Convert all existing Zsh aliases, functions, and key bindings to Fish equivalents
- Maintain consistent development environment across shell choices

## Changes Made
- **New Fish Configuration**: Created `fish/.config/fish/config.fish` with complete shell setup
- **Environment Variables**: Migrated PATH configurations, editor settings, and theme preferences
- **Aliases**: Converted all Zsh aliases including Claude CLI shortcuts and common utilities
- **Functions**: Implemented Fish versions of custom functions (history search, tmux session management, command line editing)
- **Key Bindings**: Added Ctrl+E binding for command line editing
- **Shell Enhancements**: Configured Fish-specific features like autosuggestions and path completion

## Key Features
- **Zsh Compatibility**: All existing workflows and shortcuts work identically in Fish
- **Starship Integration**: Consistent prompt across both shells
- **Development Tools**: Support for CodeEdit integration, forgit plugin, and various CLI tools
- **Interactive Enhancements**: History search with fzf, tmux session management, and command editing

## Test Plan
- [ ] Switch to Fish shell and verify all aliases work correctly
- [ ] Test history search function with \`hs\` command
- [ ] Verify tmux session creation with \`t\` command
- [ ] Check Ctrl+E key binding for command line editing
- [ ] Confirm all PATH additions are correctly applied
- [ ] Test Claude CLI shortcuts (\`cc\`, \`ccc\`, \`ccpr\`)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
EOF < /dev/null